### PR TITLE
Fix customKey throws on 'set'

### DIFF
--- a/src/GeoDocumentReference.ts
+++ b/src/GeoDocumentReference.ts
@@ -125,7 +125,10 @@ export class GeoDocumentReference {
    * @return A Promise resolved once the data has been successfully written to the backend (Note it won't resolve while you're offline).
    */
   public set(data: GeoFirestoreTypes.DocumentData, options?: GeoFirestoreTypes.SetOptions): Promise<void> {
-    return (this._document as GeoFirestoreTypes.web.DocumentReference).set(encodeSetDocument(data, options), sanitizeSetOptions(options)).then(() => null);
+    return (this._document as GeoFirestoreTypes.web.DocumentReference).set(
+      encodeSetDocument(data, options), 
+      sanitizeSetOptions(options)
+    ).then(() => null);
   }
 
   /**

--- a/src/GeoDocumentReference.ts
+++ b/src/GeoDocumentReference.ts
@@ -1,5 +1,5 @@
 import { GeoFirestoreTypes } from './GeoFirestoreTypes';
-import { encodeSetDocument, encodeUpdateDocument } from './utils';
+import { encodeSetDocument, encodeUpdateDocument, sanitizeSetOptions } from './utils';
 import { GeoCollectionReference } from './GeoCollectionReference';
 import { GeoDocumentSnapshot } from './GeoDocumentSnapshot';
 import { GeoFirestore } from './GeoFirestore';
@@ -125,7 +125,7 @@ export class GeoDocumentReference {
    * @return A Promise resolved once the data has been successfully written to the backend (Note it won't resolve while you're offline).
    */
   public set(data: GeoFirestoreTypes.DocumentData, options?: GeoFirestoreTypes.SetOptions): Promise<void> {
-    return (this._document as GeoFirestoreTypes.web.DocumentReference).set(encodeSetDocument(data, options), options).then(() => null);
+    return (this._document as GeoFirestoreTypes.web.DocumentReference).set(encodeSetDocument(data, options), sanitizeSetOptions(options)).then(() => null);
   }
 
   /**

--- a/src/GeoTransaction.ts
+++ b/src/GeoTransaction.ts
@@ -1,7 +1,7 @@
 import { GeoFirestoreTypes } from './GeoFirestoreTypes';
 import { GeoDocumentReference } from './GeoDocumentReference';
 import { GeoDocumentSnapshot } from './GeoDocumentSnapshot';
-import { encodeSetDocument, encodeUpdateDocument } from './utils';
+import { encodeSetDocument, encodeUpdateDocument, sanitizeSetOptions } from './utils';
 
 /**
  * A reference to a transaction. The `GeoTransaction` object passed to a transaction's updateFunction provides the methods to read and
@@ -60,7 +60,7 @@ export class GeoTransaction {
   ): GeoTransaction {
     const ref = ((documentRef instanceof GeoDocumentReference) ?
       documentRef['_document'] : documentRef) as GeoFirestoreTypes.web.DocumentReference;
-    (this._transaction as GeoFirestoreTypes.web.Transaction).set(ref, encodeSetDocument(data, options), options);
+    (this._transaction as GeoFirestoreTypes.web.Transaction).set(ref, encodeSetDocument(data, options), sanitizeSetOptions(options));
     return this;
   }
 

--- a/src/GeoTransaction.ts
+++ b/src/GeoTransaction.ts
@@ -60,7 +60,11 @@ export class GeoTransaction {
   ): GeoTransaction {
     const ref = ((documentRef instanceof GeoDocumentReference) ?
       documentRef['_document'] : documentRef) as GeoFirestoreTypes.web.DocumentReference;
-    (this._transaction as GeoFirestoreTypes.web.Transaction).set(ref, encodeSetDocument(data, options), sanitizeSetOptions(options));
+    (this._transaction as GeoFirestoreTypes.web.Transaction).set(
+      ref, 
+      encodeSetDocument(data, options), 
+      sanitizeSetOptions(options)
+    );
     return this;
   }
 

--- a/src/GeoWriteBatch.ts
+++ b/src/GeoWriteBatch.ts
@@ -1,5 +1,5 @@
 import { GeoFirestoreTypes } from './GeoFirestoreTypes';
-import { encodeSetDocument, encodeUpdateDocument } from './utils';
+import { encodeSetDocument, encodeUpdateDocument, sanitizeSetOptions } from './utils';
 import { GeoDocumentReference } from './GeoDocumentReference';
 
 /**
@@ -37,7 +37,7 @@ export class GeoWriteBatch {
     (this._writeBatch as GeoFirestoreTypes.web.WriteBatch).set(
       ref,
       encodeSetDocument(data, options),
-      options
+      sanitizeSetOptions(options)
     );
     return this;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -230,6 +230,20 @@ export function encodeGeoDocument(
 }
 
 /**
+ * Remove customKey attribute so firestore doesn't' reject.
+ *
+ * @param customKey The key of the document to use as the location. Otherwise we default to `coordinates`.
+ * @return The same object but without custom key
+ */
+export function sanitizeSetOptions(
+  options: GeoFirestoreTypes.SetOptions
+): GeoFirestoreTypes.SetOptions {
+  const clone = { ...options };
+  delete clone.customKey;
+  return clone;
+}
+
+/**
  * Encodes a Document used by GeoWriteBatch.set as a GeoDocument.
  *
  * @param data The document being set.

--- a/test/common.ts
+++ b/test/common.ts
@@ -18,6 +18,12 @@ export const dummyData = [
   { key: 'loc5', coordinates: new firebase.firestore.GeoPoint(67, 55), count: 4 },
   { key: 'loc6', coordinates: new firebase.firestore.GeoPoint(8, 8), count: 5 },
 ];
+// Define dummy setOptions to sanitize
+export const dummySetOptions:GeoFirestoreTypes.SetOptions = {
+  merge: true,
+  customKey: 'foobar',
+  mergeFields: ['a', 'b']
+}
 // Define examples of valid and invalid parameters
 export const invalidFirestores = [null, undefined, NaN, true, false, [], 0, 5, '', 'a', ['hi', 1]];
 export const invalidGeoFirestoreDocuments = [

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -6,11 +6,11 @@ import {
   boundingBoxBits, boundingBoxCoordinates, calculateDistance, decodeGeoDocumentData, decodeGeoQueryDocumentSnapshotData, degreesToRadians,
   encodeGeohash, encodeGeoDocument, encodeSetDocument, encodeUpdateDocument, findCoordinatesKey, generateGeoQueryDocumentSnapshot,
   geohashQueries, GEOHASH_PRECISION, geohashQuery, latitudeBitsForResolution, log2, longitudeBitsForResolution, metersToLongitudeDegrees,
-  toGeoPoint, validateGeoDocument, validateGeohash, validateLimit, validateLocation, validateQueryCriteria, wrapLongitude
+  sanitizeSetOptions, toGeoPoint, validateGeoDocument, validateGeohash, validateLimit, validateLocation, validateQueryCriteria, wrapLongitude
 } from '../src/utils';
 import {
   invalidGeoFirestoreDocuments, invalidGeohashes, invalidLocations, invalidQueryCriterias, validGeoFirestoreDocuments, validGeohashes,
-  validLocations, validQueryCriterias, dummyData
+  validLocations, validQueryCriterias, dummyData, dummySetOptions
 } from './common';
 
 const expect = chai.expect;
@@ -254,6 +254,14 @@ describe('Utils Tests:', () => {
         const doc = { g, l: data.coordinates, d: data };
         expect(encodeGeoDocument(data.coordinates, g, data)).to.deep.equal(doc);
       });
+    });
+  });
+
+  describe('Sanitize SetOptions:', () => {
+    it('sanitizeSetOptions() removes firestore-invalid keys from SetOptions', () => {
+      const { merge, mergeFields } = dummySetOptions
+      expect(sanitizeSetOptions(dummySetOptions)).to.deep.equal({ merge, mergeFields });
+      expect(sanitizeSetOptions(dummySetOptions).customKey).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
Right now calling set with a customKey fails:
```js
  setRegion = async region => {
    await notificationPreferences.doc(auth.currentUser.uid)
      .set({
        region,
      }, {
        customKey: 'region',
        merge: true
      })
  }
```

Firestore throws an error that `customKey` is not a valid option.
```
[11:44:57] [Unhandled promise rejection: FirebaseError: Unknown option 'customKey' passed to function DocumentReference.set(). Available options: merge, mergeFields]
- node_modules/@firebase/firestore/dist/index.cjs.js:346:32 in FirestoreError
- node_modules/@firebase/firestore/dist/index.cjs.js:711:37 in <unknown>
- node_modules/@firebase/firestore/dist/index.cjs.js:446:15 in forEach
- node_modules/@firebase/firestore/dist/index.cjs.js:709:12 in validateOptionNames
- node_modules/@firebase/firestore/dist/index.cjs.js:20641:24 in validateSetOptions
- node_modules/@firebase/firestore/dist/index.cjs.js:19822:37 in set
- node_modules/geofirestore/dist/geofirestore.js:1:9579 in set
```
This PR sanitizes the `set` options before forwarding them on to Firestore 😃